### PR TITLE
Refactor AbstractLambdaHandler with a cleaner API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.bundle
 /cloudlib.yaml
 /.cloudlib-source.override.yaml
+/.yardoc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,21 @@ AllCops:
 
 Layout/IndentHeredoc:
   Enabled: false
+
+# Blank lines are fine
+Layout/EmptyLines:
+  Enabled: false
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
 Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: false
 Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 Layout/EmptyLineBetweenDefs:
+  Enabled: false
+Layout/TrailingBlankLines:
   Enabled: false
 
 Naming/HeredocDelimiterNaming:
@@ -26,6 +36,8 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Enabled: false
 Metrics/AbcSize:
+  Enabled: false
+Metrics/CyclomaticComplexity:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
@@ -48,6 +60,9 @@ Style/DefWithParentheses:
 Style/LineEndConcatenation:
   Enabled: false
 
+Style/ParallelAssignment:
+  Enabled: false
+
 Style/PreferredHashMethods:
   Enabled: false
 
@@ -61,14 +76,23 @@ Style/NumericPredicate:
 Style/GuardClause:
   Enabled: false
 
-Style/SpecialGlobalVars:
-  Enabled: false
-
 Style/RaiseArgs:
   EnforcedStyle: compact
 
 Style/RedundantReturn:
   Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+# trailing commas improve diff clarity at no cost to readability
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
 
 Layout/ClosingHeredocIndentation:
   Enabled: false

--- a/lib/functions.rb
+++ b/lib/functions.rb
@@ -40,9 +40,11 @@ module Functions
     end
 
     unless klass <= AbstractLambdaHandler
-      warn(['Functions.register_handler:',
-            'expected klass to be subclass of AbstractLambdaHandler, got',
-            klass.ancestors.inspect].join(' '))
+      warn([
+        'Functions.register_handler:',
+        'expected klass to be subclass of AbstractLambdaHandler, got',
+        klass.ancestors.inspect,
+      ].join(' '))
     end
 
 

--- a/lib/functions.rb
+++ b/lib/functions.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Top level lambda function wrapper module
+#
+# Define a new Lambda function handler by subclassing
+# {Functions::AbstractLambdaHandler}. Require the class from main.rb, and use
+# the `.process` class method on the subprocess as the Lambda entrypoint. If
+# you want the function to be accessible via the CLI for testing, then call
+# {Functions.register_handler} with the class.
+#
+module Functions
+
+  # @return [Hash{String => Class}] A mapping from string CLI labels to
+  #   {AbstractLambdaHandler} subclasses.
+  def self.registered_classes
+    @registered_classes ||= {}
+  end
+
+  # Get a registered class
+  #
+  # @param [String] cli_name
+  # @return [Class]
+  def self.get_class(cli_name)
+    registered_classes.fetch(cli_name)
+  end
+
+  # Add a Lambda handler class to the set of known classes with friendly CLI
+  # labels. These labels are used to invoke the handlers on the command line
+  # for local development or testing.
+  #
+  # @param [AbstractLambdaHandler] klass The lambda handler to register
+  # @param [String] cli_name A friendly CLI label
+  # @param [Boolean] override Whether to allow replacing existing methods
+  #
+  def self.register_handler(klass, cli_name, override: false)
+    unless klass.is_a?(Class)
+      raise ArgumentError.new(
+        "klass must be a Class, got: #{klass.inspect}"
+      )
+    end
+
+    unless klass <= AbstractLambdaHandler
+      warn(['Functions.register_handler:',
+            'expected klass to be subclass of AbstractLambdaHandler, got',
+            klass.ancestors.inspect].join(' '))
+    end
+
+
+    unless cli_name.is_a?(String)
+      raise ArgumentError.new(
+        "cli_name must be a String, got #{cli_name.inspect}"
+      )
+    end
+
+    if registered_classes.include?(cli_name) && !override
+      raise KeyError.new('Duplicate handler name: ' + cli_name.inspect)
+    end
+
+    registered_classes[cli_name] = klass
+  end
+end
+
+require_relative 'functions/abstract_lambda_handler'

--- a/lib/functions/abstract_lambda_handler.rb
+++ b/lib/functions/abstract_lambda_handler.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module Functions
+
+  # Parent class for lambda handlers. New handlers should inherit from this
+  # class.
+  #
+  # Lambda operation:
+  # Handlers must override the {#lambda_main} method. The
+  # recommended default lambda handler entrypoint is the class method
+  # `.process()` provided by this class, which instantiates the class using
+  # config from environment variables and then calls `#lambda_main`.
+  #
+  # CLI operation:
+  # Subclasses should invoke {Functions.register_handler} and define a method
+  # {#cli_main} to make themselves available to run from the CLI. The CLI
+  # portion is not strictly necessary, but is useful for local development and
+  # testing.
+  #
+  class AbstractLambdaHandler
+
+    # Initializer for Lambda handlers. Override this method in subclasses with
+    # any specialized functionality, but don't forget to call super!
+    #
+    # @param [Integer] log_level Default log level for `#log`
+    # @param [Boolean] dry_run Whether to enable dry run mode
+    #
+    def initialize(log_level: Logger::INFO, dry_run: true)
+      @dry_run = dry_run
+      log.level = log_level
+      log.info("super#initialize, dry_run: #{dry_run.inspect}")
+    end
+
+    # @return [Boolean] Whether we are currently running in dry run mode.
+    def dry_run?
+      !!@dry_run
+    end
+
+    # Logger for handlers (class method)
+    # @return [Logger]
+    def self.log
+      @log ||= Logger.new(STDERR).tap { |l|
+        l.progname = name
+      }
+    end
+
+    # Logger for handlers
+    # @return [Logger]
+    def log
+      @log ||= self.class.log
+    end
+
+    # Main entrypoint for running the handler with an AWS Lambda event.
+    # Subclasses must implement this method.
+    #
+    # @param [Hash,String] event The event received from AWS Lambda
+    # @param context The context received from AWS Lambda
+    #
+    # @return [Object]
+    #
+    def lambda_main(event:, context:)
+      _ = event, context # discard args
+      raise NotImplementedError.new('Subclasses must implement lambda_main')
+    end
+
+    # Main entrypoint for running the handler from the CLI. Subclasses should
+    # implement this method if they want to be run on the command line.
+    #
+    # @param [Array] args The ARGV argument array as received from the command
+    #   line.
+    def cli_main(args)
+      _ = args
+      raise NotImplementedError.new('Subclasses should implement cli_main')
+    end
+
+    # Instantiate the handler and call {#lambda_main}. This is the top level
+    # entrypoint called by `main.rb`. Subclasses are NOT expected to override
+    # this method unless they want to memoize or otherwise change behavior for
+    # handler object instantiation (e.g. to reuse the same handler instance
+    # across many events).
+    #
+    # @param [Hash,String] event The event received from AWS Lambda
+    # @param context The context received from AWS Lambda
+    #
+    # @return [Object]
+    #
+    # @see .new_with_env_config
+    # @see #lambda_main
+    #
+    def self.process(event:, context:)
+      log.info('Instantiating handler to process lambda event')
+      # Lambda defaults to real run mode
+      new_with_env_config(dry_run_default: false)
+        .lambda_main(event: event, context: context)
+    end
+
+    # Instantiate the handler and call {#cli_main}.
+    #
+    # @param [Array] args The ARGV argument array as received from the command
+    #   line.
+    #
+    # @see .new_with_env_config
+    # @see #cli_main
+    #
+    def self.cli_process(args)
+      # CLI defaults to dry run mode
+      new_with_env_config(dry_run_default: true)
+        .cli_main(args)
+    end
+
+    # Instantiate the handler with defaults from environment variables.
+    #
+    # If `DEBUG` is set and nonempty, default to `DEBUG` logging and dry run
+    # mode. Otherwise default to `INFO` logging and real run mode.
+    #
+    # Override the log level with `LOG_LEVEL`, if set.
+    #
+    # @see #initialize
+    #
+    # @param kwargs Passed through to .new
+    #
+    # @return [AbstractLambdaHandler]
+    #
+    def self.new_with_env_config(dry_run_default: true, **kwargs)
+      # Enable debug mode if $DEBUG is set and nonempty
+      if ENV['DEBUG'] && !ENV['DEBUG'].empty?
+        dry_run = true
+        log_level = Logger::DEBUG
+      else
+        dry_run = dry_run_default
+        log_level = Logger::INFO
+      end
+
+      # Disable dry run and run in real mode if REAL_RUN is set
+      if ENV['REAL_RUN'] && !ENV['REAL_RUN'].empty?
+        dry_run = false
+      end
+
+      # override log level from $LOG_LEVEL if provided
+      if ENV['LOG_LEVEL'] && !ENV['LOG_LEVEL'].empty?
+        log_level = Integer(ENV.fetch('LOG_LEVEL'))
+      end
+
+      log.debug('Initializing with config from env')
+
+      new(log_level: log_level, dry_run: dry_run, **kwargs)
+    end
+  end
+
+end
+

--- a/lib/kms_monitor/cloudtrail.rb
+++ b/lib/kms_monitor/cloudtrail.rb
@@ -80,8 +80,10 @@ module IdentityKMSMonitor
       begin
         result = dynamo.get_item(
           table_name: ENV['DDB_TABLE'],
-          key: { 'UUID' => uuid,
-                 'Timestamp' => timestamp },
+          key: {
+            'UUID' => uuid,
+            'Timestamp' => timestamp,
+          },
           consistent_read: false
                                  )
       rescue Aws::DynamoDB::Errors::ServiceError => error
@@ -101,12 +103,12 @@ module IdentityKMSMonitor
         'Correlated' => '1',
         'CTData' => ctdata,
         'CWData' => cwdata,
-        'TimeToExist' => ttlstring
+        'TimeToExist' => ttlstring,
       }
 
       params = {
         table_name: table_name,
-        item: item
+        item: item,
       }
 
       begin
@@ -139,7 +141,7 @@ module IdentityKMSMonitor
         action: @action,
         uuid: @uuid,
         timestamp: @timestamp,
-        context: @context
+        context: @context,
       }
     end
 

--- a/main.rb
+++ b/main.rb
@@ -2,116 +2,83 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+require_relative './lib/functions'
+
+# To add a new handler function, create a subclass of
+# {Functions::AbstractLambdaHandler}.
+#
+# == Handling Lambda events:
+#
+# In the subclass, override `#lambda_main` to define what should happen when
+# the lambda receives an event. The top level entrypoint for the lambda will be
+# a class method provided by the parent class: {AbstractLambdaHandler.process}.
+# You will not normally need to override this `.process` class method, which is
+# the handler method that should be referenced in AWS Lambda configuration when
+# creating the Lambda itself:
+#
+#   resource "aws_lambda_function" "my-lambda" {
+#     handler = "main.MyModule::MyClass.process"
+#     ...
+#
+# == Handling CLI events:
+#
+# If you want to be able to call a lambda handler subclass from this CLI for
+# development or testing, call {Functions.register_handler} to associate the
+# handler with a CLI name.
+#
+# In the subclass, override `#cli_main` to define what should happen when the
+# handler is run on the CLI. The corresponding class method provided by the
+# parent class is {AbstractLambdaHandler.process_cli}, which you will not
+# normally need to override.
+#
+# The CLI methods are useful for testing, but not necessary.
+#
+
+
+# Require handler modules here so they can be loaded by CLI or by AWS Lambda.
 require_relative './lib/audit'
 require_relative './lib/kms_monitor'
 
-# Parent class for lambda handlers
-class AbstractLambdaHandler
-  def self.klass
-    raise NotImplementedError.new('Must override klass to point to runner')
+# ^ Load new function libraries here
+
+
+# Main CLI entrypoint
+#
+# rubocop:disable Style/StderrPuts
+def usage
+  STDERR.puts "usage: #{$0} LAMBDA [ARGS...]\n\n"
+  STDERR.puts 'known lambdas:'
+
+  maxlen = Functions.registered_classes.keys.map(&:length).max
+  Functions.registered_classes.sort.each do |name, klass|
+    puts '  - ' + name.ljust(maxlen) + "\t\t(#{klass.name})"
   end
-
-  def self.process(event:, context:)
-    @lambda_event = event
-    @lambda_context = context
-    cli_run([])
-  end
-
-  def self.cli_run(args)
-    # Enable debug mode if DEBUG is set and nonempty
-    if ENV['DEBUG'].present?
-      dry_run = true
-      log_level = Logger::DEBUG
-    else
-      dry_run = false
-      log_level = Logger::INFO
-    end
-
-    # override log level from $LOG_LEVEL if provided
-    if ENV['LOG_LEVEL'].present?
-      log_level = Integer(ENV.fetch('LOG_LEVEL'))
-    end
-
-    ga = klass.new(log_level: log_level, dry_run: dry_run)
-    ga.main(args)
-  end
+  STDERR.puts
+  STDERR.puts <<-EOM
+Set REAL_RUN=1 to enable real run mode (dry run is default for CLI)
+Set DEBUG=1 to enable dry run and debug output
+Set LOG_LEVEL=N to set log level to any integer N
+  EOM
 end
 
-# Top level lambda function wrapper module
-module Functions
-
-  # Add lamba function classes in here. They should respond to the class
-  # methods (not instance methods):
-  # - .process()
-  # - .cli_run()
-  # - .cli_name()
-
-  def self.known_classes
-    Functions.constants.map { |c| Functions.const_get(c) }
-             .select { |c| c.is_a?(Class) }
-  end
-
-  def self.get_class(cli_name)
-    klass = known_classes.find { |c| c.cli_name == cli_name }
-    unless klass
-      raise KeyError.new('Could not find class named ' + cli_name.inspect)
-    end
-    klass
-  end
-
-  # Lambda handler for audit-github
-  class GithubAuditHandler < AbstractLambdaHandler
-    def self.klass
-      IdentityAudit::GithubAuditor
-    end
-
-    def self.cli_name
-      'audit-github'
-    end
-  end
-
-  # Lambda handler for audit-aws
-  class AWSAuditHandler < AbstractLambdaHandler
-    def self.klass
-      IdentityAudit::AwsIamAuditor
-    end
-
-    def self.cli_name
-      'audit-aws'
-    end
-  end
-
-  # Lambda handler for cloudtrail-to-dynamo
-  class KMSCloudTrailHandler < AbstractLambdaHandler
-    def self.klass
-      IdentityKMSMonitor::CloudTrailToDynamoHandler
-    end
-
-    def self.cli_name
-      'cloudtrail-to-dynamo'
-    end
-  end
-end
 
 def cli_main
   if ARGV.empty?
-    STDERR.puts "usage: #{$0} LAMBDA [ARGS...]\n\n"
-    STDERR.puts 'known lambdas:'
-    Functions.known_classes.each do |c|
-      puts '  - ' + c.cli_name
-    end
-    STDERR.puts
-    STDERR.puts('Set DEBUG=1 to enable dry run and debug output')
-    STDERR.puts('Set LOG_LEVEL=N to set log level to any integer N')
-
+    usage
     exit 1
+  end
+
+  if %w[-h --help].include?(ARGV.first)
+    usage
+    exit
   end
 
   command_name = ARGV.shift
 
   klass = Functions.get_class(command_name)
-  klass.cli_run(ARGV)
+  klass.cli_process(ARGV)
 end
+# rubocop:enable Style/StderrPuts
 
 if $0 == __FILE__
   cli_main

--- a/spec/unit/kms_monitor/cloudtrail_spec.rb
+++ b/spec/unit/kms_monitor/cloudtrail_spec.rb
@@ -1,5 +1,5 @@
 file = File.open "spec/support/test_cloudtrail_records.json"
-test_records = JSON.load(file)
+test_event = JSON.load(file)
 
 class FakeDynamoClient
   def inner_client
@@ -41,7 +41,7 @@ RSpec.describe IdentityKMSMonitor::CloudTrailToDynamoHandler do
                  "Timestamp"=>"2019-03-08T13:32:07Z",
                  "CWData"=>"some cloudwatch data"}})
       instance = IdentityKMSMonitor::CloudTrailToDynamoHandler.new(dynamo: fake_dynamo)
-      instance.inner_process(test_records)
+      instance.process_event(test_event)
       final_entry = fake_dynamo.get_item(
         {:table_name=>"fake_table",
          :key=>{"UUID"=>"ad891a65-4560-4669-b422-b61cd5f9c861-password-digest",

--- a/spec/unit/main_spec.rb
+++ b/spec/unit/main_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe 'main.rb' do
+  describe 'lambda handlers' do
+    it 'have all the expected entrypoints' do
+
+      # Add new entrypoints here as they are added. This list should match all
+      # of the lambda handlers known to terraform.
+      handler_methods = [
+        'IdentityAudit::GithubAuditor.process',
+        'IdentityAudit::AwsIamAuditor.process',
+        'IdentityKMSMonitor::CloudTrailToDynamoHandler.process',
+      ]
+
+      handler_methods.each do |handler|
+        klass_s, method_s = handler.split('.', 2)
+
+        klass = Module.const_get(klass_s)
+
+        expect(klass).to be_a(Class)
+        expect(klass.ancestors).to include(Functions::AbstractLambdaHandler)
+
+        expect(klass).to respond_to(method_s)
+
+        method = klass.method(method_s)
+
+        # assert that the method accepts event and context keywords
+        expect(method.parameters).to include([:keyreq, :event])
+        expect(method.parameters).to include([:keyreq, :context])
+      end
+    end
+  end
+end


### PR DESCRIPTION
The v0 API for lambda handlers left a decent amount to be desired. There
was too much functionality comingled in the main.rb file. And there was
an unnecessary and confusing duplication of classes between the handler
class and the class that actually did all the work.

Instead, make AbstractLambdaHandler the preferred parent class for all
lambda handlers, and move common functionality like loggers and
initialization into the parent class.

Also use this parent class to define the API for both Lambda and CLI
invocations.

The lambda invocation uses a `.process(event:, context:)` class method,
which will be called directly by AWS lambda.

The CLI invocation uses a `.process_cli(args)` class method, which will
be called by the CLI main routine.

Each of these class methods then uses
AbstractLambdaHandler.new_with_env_config to determine what the defaults
should be for the log_level and dry_run mode, taking input from
environment variables. Then it instantiates the class and runs either
`#lambda_main(event:, context:)` or `#cli_main(args)`, which is defined
by the subclass and contains all the unique processing behavior.

We've moved most of this common code under the Functions module to keep
the top level namespace less cluttered.

And we also simplify management of the CLI labels for the handlers by
using a new method, `Functions.register_handler(klass, label)`. This
method takes the handler subclass and a label and makes it available for
running from the CLI.

**In summary**:

Now handlers will directly subclass Functions::AbstractLambdaHandler to
inherit some useful functionality like logs. Subclasses must override
`lambda_main(event:, context:)` to perform the lambda's main functions.
Subclasses may also override `cli_main(args)` to perform anything
intended to be exposed to the CLI for development or testing.

The standard pattern for referring to the handler from lambda will be:

```hcl
resource "aws_lambda_function" "my-lambda" {
  handler = "main.MyModule::MyClass.process"
  ...
```

The handler library must be require'd from `main.rb`, but AWS Lambda
then just runs the `.process` class method directly. This avoids the
need to duplicate the handler method definition anywhere else.

So for example, this will be the diff to update the existing lambdas to
use the new handlers:

```diff
diff --git a/terraform-common/lambdas.tf b/terraform-common/lambdas.tf
index 6bda9dfb..3876b717 100644
--- a/terraform-common/lambdas.tf
+++ b/terraform-common/lambdas.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "audit-github" {
   function_name    = "audit-github"
   description      = "18F/identity-lambda-functions: GithubAuditor -- auditor of Github teams and membership"
   role             = "${aws_iam_role.lambda-audit-github.arn}"
-  handler          = "main.Functions::GithubAuditHandler.process"
+  handler          = "main.IdentityAudit::GithubAuditor.process"
   runtime          = "ruby2.5"
   timeout          = 30 # seconds

@@ -121,7 +121,7 @@ resource "aws_lambda_function" "audit-aws" {
   function_name    = "audit-aws"
   description      = "18F/identity-lambda-functions: AwsIamAuditor -- auditor of AWS IAM users and 2FA setup"
   role             = "${aws_iam_role.lambda-audit-aws.arn}"
-  handler          = "main.Functions::AWSAuditHandler.process"
+  handler          = "main.IdentityAudit::AwsIamAuditor.process"
   runtime          = "ruby2.5"
   timeout          = 30 # seconds
```