### PR TITLE
Add the KMS CloudWatch Lambda

### DIFF
--- a/lib/kms_monitor.rb
+++ b/lib/kms_monitor.rb
@@ -6,3 +6,4 @@ module IdentityKMSMonitor
 end
 
 require_relative './kms_monitor/cloudtrail'
+require_relative './kms_monitor/cloudwatch'

--- a/lib/kms_monitor/cloudwatch.rb
+++ b/lib/kms_monitor/cloudwatch.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'logger'
+require 'aws-sdk-dynamodb'
+
+module IdentityKMSMonitor
+
+  # Class for inputting CloudWatch events into DynamoDB
+  class CloudWatchKMSHandler < Functions::AbstractLambdaHandler
+
+    attr_reader :dynamo
+
+    Functions.register_handler(self, 'cloudwatch-kms')
+
+    def initialize(log_level: Logger::INFO, dry_run: true, dynamo: nil)
+      super(log_level: log_level, dry_run: dry_run)
+
+      begin
+        @dynamo = dynamo || Aws::DynamoDB::Client.new
+      rescue StandardError
+        log.error('Failed to create DynamoDB client. Do you have AWS creds?')
+        raise
+      end
+    end
+
+    def cli_main(_args)
+      log.info('Reading JSON event from STDIN...')
+      event = JSON.parse(STDIN.read)
+      process_event(event)
+    end
+
+    # This is the main lambda handler function
+    #
+    # @param [Hash, String] event The event received from AWS Lambda
+    # @param context The context received from AWS Lambda
+    #
+    def lambda_main(event:, context:)
+      _ = context
+      process_event(event)
+    end
+
+    # @param [Hash] event
+    def process_event(event)
+      log.info("process_event: #{event.inspect}")
+      process_records(event.fetch('Records'))
+    end
+
+    def insert_into_db(uuid, timestamp, data)
+      table_name = ENV.fetch('DDB_TABLE')
+      ttl = Time.now.utc + Integer(ENV.fetch('RETENTION_DAYS'))
+      ttlstring = ttl.strftime('%Y-%m-%dT%H:%M:%SZ')
+      item = {
+        'UUID' => uuid,
+        'Timestamp' => timestamp,
+        'Correlated' => '0',
+        'CWData' => data,
+        'TimeToExist' => ttlstring,
+      }
+
+      params = {
+        table_name: table_name,
+        item: item,
+      }
+
+      begin
+        dynamo.put_item(params)
+        log.info "Added event for user_uuid: #{uuid}"
+
+      rescue Aws::DynamoDB::Errors::ServiceError => error
+        log.error "Failure adding event: #{error.message}"
+        raise
+      end
+    end
+
+    def decompress(compressed_data)
+      data = Base64.decode64(compressed_data)
+      uncompressed_data = Zlib::GzipReader.new(
+        StringIO.new(data), external_encoding: data.encoding).read
+      uncompressed_data
+    end
+
+    def get_db_record(uuid, timestamp)
+      begin
+        result = dynamo.get_item(
+          table_name: ENV.fetch('DDB_TABLE'),
+          key: {
+            'UUID' => uuid,
+            'Timestamp' => timestamp,
+          },
+          consistent_read: true
+                                 )
+      rescue Aws::DynamoDB::Errors::ServiceError => error
+        log.error "Failure retrieving record from table: #{error.message}"
+        raise
+      end
+
+      result.item
+    end
+
+    def update_db_record(dbrecord, kmsevent)
+      # If we don't have any CTData, then we are reprocessing an unmatched
+      # existing record. If the record is correlated, no update is required.
+      if dbrecord['CTData'].nil? || dbrecord['Correlated'] == '1'
+        return
+      end
+
+      table_name = ENV.fetch('DDB_TABLE')
+      ttl = Time.now.utc + Integer(ENV.fetch('RETENTION_DAYS'))
+      ttlstring = ttl.strftime('%Y-%m-%dT%H:%M:%SZ')
+      item = {
+        'UUID' => kmsevent.get_key,
+        'Timestamp' => kmsevent.timestamp,
+        'Correlated' => '1',
+        'CTData' => dbrecord.fetch('CTData'),
+        'CWData' => kmsevent.as_json,
+        'TimeToExist' => ttlstring,
+      }
+
+      params = {
+        table_name: table_name,
+        item: item,
+      }
+
+      begin
+        dynamo.put_item(params)
+
+      rescue Aws::DynamoDB::Errors::ServiceError => error
+        log.error "Failure adding event: #{error.message}"
+        raise
+      end
+    end
+
+    def process_records(records)
+      records&.each do |record|
+        process_record(record)
+      end
+    end
+
+    def process_record(record)
+      data = {}
+      record.each do |key, value|
+        if key == 'kinesis'
+          data = value.fetch('data')
+        end
+      end
+
+      data = decompress(data)
+
+      logdata = JSON.parse(data)
+      log.info("parsed log data: #{logdata.inspect}")
+
+      return if logdata.fetch('messageType') == 'CONTROL_MESSAGE'
+
+      logevents = logdata.fetch('logEvents')[0].fetch('extractedFields')
+
+      kmsevent = CloudWatchKMSEvent.new
+
+      timestamp = Time.parse(logevents.fetch('datetime'))
+      kmsevent.timestamp = timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+      # cleanup extra character at beginning of Json string
+      jsondata = logevents.fetch('json')
+      jsondata = jsondata[1..-1]
+
+      jsondata = JSON.parse(jsondata)
+
+      encryption_context = jsondata.fetch('kms').fetch('encryption_context')
+      kmsevent.context = encryption_context.fetch('context')
+      kmsevent.uuid = encryption_context.fetch('user_uuid')
+      kmsevent.action = jsondata.fetch('kms').fetch('action')
+
+      dbrecord = get_db_record(kmsevent.get_key, kmsevent.timestamp)
+
+      if dbrecord
+        update_db_record(dbrecord, kmsevent)
+      else
+        insert_into_db(kmsevent.get_key, kmsevent.timestamp, kmsevent.to_h)
+      end
+    end
+  end
+
+  # This class represents KMS events we retrieve from CloudWatch.
+  class CloudWatchKMSEvent
+    attr_accessor :action, :context, :uuid, :timestamp
+
+    def get_key()
+      @uuid + '-' + @context
+    end
+
+    def to_h(_options = {})
+      {
+        action: @action,
+        uuid: @uuid,
+        timestamp: @timestamp,
+        context: @context,
+      }
+    end
+
+    def to_json(*options)
+      to_h(*options).to_json(*options)
+    end
+  end
+end

--- a/main.rb
+++ b/main.rb
@@ -44,7 +44,6 @@ require_relative './lib/kms_monitor'
 
 # Main CLI entrypoint
 #
-# rubocop:disable Style/StderrPuts
 def usage
   STDERR.puts "usage: #{$0} LAMBDA [ARGS...]\n\n"
   STDERR.puts 'known lambdas:'
@@ -60,7 +59,6 @@ Set DEBUG=1 to enable dry run and debug output
 Set LOG_LEVEL=N to set log level to any integer N
   EOM
 end
-
 
 def cli_main
   if ARGV.empty?
@@ -78,7 +76,6 @@ def cli_main
   klass = Functions.get_class(command_name)
   klass.cli_process(ARGV)
 end
-# rubocop:enable Style/StderrPuts
 
 if $0 == __FILE__
   cli_main

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,3 +99,12 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }

--- a/spec/support/fake_dynamodb.rb
+++ b/spec/support/fake_dynamodb.rb
@@ -1,0 +1,28 @@
+class FakeDynamoClient
+  def inner_client
+    @inner_client ||= Aws::DynamoDB::Client.new(stub_responses: true)
+  end
+
+  # We'll keep a hash of [table, uuid, timestamp] to records
+  def objects
+    @objects ||= {}
+  end
+
+  def object_key(table_name, item)
+    uuid = item["UUID"]
+    timestamp = item["Timestamp"]
+    [table_name, uuid, timestamp]
+  end
+
+  def get_item(params)
+    object_key = object_key(params[:table_name], params[:key])
+    inner_client.stub_responses(:get_item, {item: objects[object_key]})
+    inner_client.get_item(params)
+  end
+
+  def put_item(params)
+    item = params[:item]
+    object_key = object_key(params[:table_name], item)
+    objects[object_key] = item
+  end
+end

--- a/spec/unit/kms_monitor/cloudtrail_spec.rb
+++ b/spec/unit/kms_monitor/cloudtrail_spec.rb
@@ -3,35 +3,6 @@ file = File.open File.expand_path(
 
 test_event = JSON.load(file)
 
-class FakeDynamoClient
-  def inner_client
-    @inner_client ||= Aws::DynamoDB::Client.new(stub_responses: true)
-  end
-
-  # We'll keep a hash of [table, uuid, timestamp] to records
-  def objects
-    @objects ||= {}
-  end
-
-  def object_key(table_name, item)
-    uuid = item["UUID"]
-    timestamp = item["Timestamp"]
-    [table_name, uuid, timestamp]
-  end
-
-  def get_item(params)
-    object_key = object_key(params[:table_name], params[:key])
-    inner_client.stub_responses(:get_item, {item: objects[object_key]})
-    inner_client.get_item(params)
-  end
-
-  def put_item(params)
-    item = params[:item]
-    object_key = object_key(params[:table_name], item)
-    objects[object_key] = item
-  end
-end
-
 RSpec.describe IdentityKMSMonitor::CloudTrailToDynamoHandler do
   describe 'the process method' do
     it 'writes a match to an existing DB entry' do

--- a/spec/unit/kms_monitor/cloudwatch_spec.rb
+++ b/spec/unit/kms_monitor/cloudwatch_spec.rb
@@ -1,0 +1,43 @@
+control_event = {"Records"=>[{"kinesis"=>{"kinesisSchemaVersion"=>"1.0", "partitionKey"=>"3e21f5e8240cbb048271af4fdb892a1c", "sequenceNumber"=>"49594019693003114422879448339514879444680299351132602370", "data"=>"H4sIAAAAAAAAADWOwQqCQBRFf2WYdYQRariLMBdZQgYtImLSlz7SGZk3FiH+e6PW8nAv956O10AkCjh9GuAB3ySH0zGJb/swTddRyGdcvSXoIalUm7+FycpYFWSDShWRVm1js4lSo0HUE1J7p0xjY1DJLVYGNPHgch174QukGbDjmE91g1bDiNqOLVzXc1zH85cr35v99QaBc8x+euynF7BNCdkTZcFKEJUpmXqw3C6hFMMz26EEQmI0qs15f+2/iTNXgvIAAAA=", "approximateArrivalTimestamp"=>1556050674.253}, "eventSource"=>"aws:kinesis", "eventVersion"=>"1.0", "eventID"=>"shardId-000000000000:49594019693003114422879448339514879444680299351132602370", "eventName"=>"aws:kinesis:record", "invokeIdentityArn"=>"arn:aws:iam::19791211:role/loginenv-lambda-cloudwatch-kms", "awsRegion"=>"jeffs-basement", "eventSourceARN"=>"arn:aws:kinesis:jeffs-basement:19791211:stream/loginenv-kms-app-events"}]}
+
+decrypt_message = {"messageType"=>"DATA_MESSAGE", "owner"=>"19791211", "logGroup"=>"loginenv_/srv/idp/shared/log/kms.log", "logStream"=>"idp-i-05ea7d1d35f8df399.loginenv.identitysandbox.gov", "subscriptionFilters"=>["loginenv-kms-app-log"], "logEvents"=>[{"id"=>"34701420244984930149589218301075272436152625254143492097", "timestamp"=>1556065500774, "message"=>"I, [2019-04-24T00:25:00.774192 #5666]  INFO -- : {\"kms\":{\"action\":\"decrypt\",\"encryption_context\":{\"context\":\"password-digest\",\"user_uuid\":\"cafecafe-b4e6-4a4c-8e9d-beef2e191f0b\"}}}", "extractedFields"=>{"datetime"=>"2019-04-24T00:25:00.774192 #5666", "json"=>": {\"kms\":{\"action\":\"decrypt\",\"encryption_context\":{\"context\":\"password-digest\",\"user_uuid\":\"cafecafe-b4e6-4a4c-8e9d-beef2e191f0b\"}}}", "type"=>"I,", "whitespace"=>"--", "info"=>"INFO"}}]}.to_json
+
+def make_encoded_gzip(json)
+  gz = Zlib::GzipWriter.new(StringIO.new)
+  gz << json
+  Base64.encode64(gz.close.string)
+end
+
+compressed_decrypt_message = make_encoded_gzip(decrypt_message)
+
+decrypt_event = {"Records"=>[{"kinesis"=>{"kinesisSchemaVersion"=>"1.0", "partitionKey"=>"724fd507781225d0fe45ad5afe3b85fd", "sequenceNumber"=>"49594019693003114422879452068920468967293942684815720450", "data"=>compressed_decrypt_message, "approximateArrivalTimestamp"=>1556065507.32}, "eventSource"=>"aws:kinesis", "eventVersion"=>"1.0", "eventID"=>"shardId-000000000000:49594019693003114422879452068920468967293942684815720450", "eventName"=>"aws:kinesis:record", "invokeIdentityArn"=>"arn:aws:iam::19791211:role/loginenv-lambda-cloudwatch-kms", "awsRegion"=>"jeffs-basement", "eventSourceARN"=>"arn:aws:kinesis:jeffs-basement:19791211:stream/loginenv-kms-app-events"}]}
+
+RSpec.describe IdentityKMSMonitor::CloudWatchKMSHandler do
+  describe 'something in the cloudtrail class' do
+    it 'can process an empty list of records' do
+      ENV['DDB_TABLE'] = 'fake_table'
+      fake_dynamo = FakeDynamoClient.new
+      instance = IdentityKMSMonitor::CloudWatchKMSHandler.new(dynamo: fake_dynamo)
+      instance.process_event({ 'Records' => [] })
+    end
+    it 'can process a control message' do
+      ENV['DDB_TABLE'] = 'fake_table'
+      ENV['RETENTION_DAYS'] = '365'
+      fake_dynamo = FakeDynamoClient.new
+      instance = IdentityKMSMonitor::CloudWatchKMSHandler.new(dynamo: fake_dynamo)
+      instance.process_event(control_event)
+    end
+    it 'can process a decrypt event' do
+      ENV['DDB_TABLE'] = 'fake_table'
+      ENV['RETENTION_DAYS'] = '365'
+      fake_dynamo = FakeDynamoClient.new
+      instance = IdentityKMSMonitor::CloudWatchKMSHandler.new(dynamo: fake_dynamo)
+      instance.process_event(decrypt_event)
+      final_entry = fake_dynamo.get_item(
+        {:table_name=>"fake_table",
+         :key=>{"UUID"=>"cafecafe-b4e6-4a4c-8e9d-beef2e191f0b-password-digest",
+                "Timestamp"=>"2019-04-24T00:25:00Z"}})
+      expect(final_entry.item['CWData']['context']).to eq 'password-digest'
+    end
+  end
+end


### PR DESCRIPTION
1. Move the FakeDynamo client into its own file so multiple lambdas can use it.
2. Comment out Rubocop until the issue (on a private repo) with native extensions is fixed.
3. From actually running Rubocop, some changes to main.rb.

The CloudWatch lambda gets KMS events from Kinesis (or anything else that can feed KMS events to Lambda, but we use Kinesis), sees if they have already been put in the database by the Cloudtrail lambda, and either marks them correlated or adds a new one.