### PR TITLE
Fix up CircleCI build process.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,11 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.5-node-browsers
+      - image: circleci/ruby:2.5-node-browsers
+        environment:
+          # Override CircleCI default directory /usr/local/bundle
+          # We do want the bundler config to be part of the built .zip
+          BUNDLE_APP_CONFIG: '.bundle'
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,12 @@ source 'https://rubygems.org'
 group 'development' do
   gem 'pry', '~> 0.12'
   gem 'rake', '~> 12'
+  gem 'rubocop', '~> 0.58.0', require: false
+end
+
+group 'test' do
   gem 'rspec', '~> 3.8'
   gem 'rspec_junit_formatter', '~> 0.4'
-  gem 'rubocop', '~> 0.58.0', require: false
 end
 
 gem 'aws-sdk-dynamodb', '~> 1.25'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,15 +29,15 @@ GEM
     diff-lcs (1.3)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.2)
     jmespath (1.4.0)
     method_source (0.9.2)
     multipart-post (2.0.0)
     netrc (0.11.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.12.1)
-    parser (2.5.1.2)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     pry (0.12.2)
@@ -74,7 +74,7 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     subprocess (1.3.2)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.5.0)
 
 PLATFORMS
   ruby

--- a/lib/functions/abstract_lambda_handler.rb
+++ b/lib/functions/abstract_lambda_handler.rb
@@ -89,6 +89,7 @@ module Functions
     #
     def self.process(event:, context:)
       log.info('Instantiating handler to process lambda event')
+      log.info("Current git revision: #{deployed_git_revision}")
       # Lambda defaults to real run mode
       new_with_env_config(dry_run_default: false)
         .lambda_main(event: event, context: context)
@@ -144,6 +145,10 @@ module Functions
       log.debug('Initializing with config from env')
 
       new(log_level: log_level, dry_run: dry_run, **kwargs)
+    end
+
+    def self.deployed_git_revision
+      File.read(File.join(File.dirname(__FILE__), '../../REVISION.txt')).chomp
     end
   end
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 set -eux
 cd "$(dirname "$0")/.."
-bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+bundle install --deployment --without=development --jobs=4 --retry=3 --path vendor/bundle
+
+# show resulting bundler config values
+bundle config

--- a/scripts/package-lambda.sh
+++ b/scripts/package-lambda.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euxo pipefail
 
+# Record current git revision so code can read it out of the .zip bundle
+git rev-parse HEAD > REVISION.txt
+
 pwd
 ls -la
 


### PR DESCRIPTION
- Override $BUNDLE_APP_CONFIG to use default .bundle/ directory. This
  causes the .bundle/config to correctly be part of the .zip bundle so
  that our settings around bundler groups take effect in Lambda.
- Move rubocop to development group, keep rspec in testing group. We currently
  have problems with C extensions loaded by rubocop. https://github.com/18F/identity-devops/issues/1414
- Write the git revision to disk as part of building the .zip bundle.
- Log the git revision as part of the Lambda main entrypoint.