### PR TITLE
Increase retry counter for CT events

### DIFF
--- a/lib/kms_monitor/cloudtrail.rb
+++ b/lib/kms_monitor/cloudtrail.rb
@@ -104,7 +104,7 @@ module IdentityKMSMonitor
         insert_into_db(ctevent.get_key, dbrecord.fetch('Timestamp'), body,
                        dbrecord.fetch('CWData'), 1)
         log_event_sns(ctevent, body.fetch('id'), true)
-      elsif retrycount <= 5
+      elsif retrycount <= 20
         # put message back on queue
         log.info('No matching CloudWatch event found. Requeuing this event.')
         delay = calculate_delay(retrycount)


### PR DESCRIPTION
Periodically we are receiving infrequent events from CloudWatch that are delayed up to 2:30 hours.  By increasing the retry count to 20 we can avoid false positive alerts. 