### PR TITLE
Increase number of retries on CloudTrail events

### DIFF
--- a/lib/kms_monitor/cloudtrail.rb
+++ b/lib/kms_monitor/cloudtrail.rb
@@ -106,7 +106,7 @@ module IdentityKMSMonitor
         insert_into_db(ctevent.get_key, dbrecord.fetch('Timestamp'), body,
                        dbrecord.fetch('CWData'), 1)
         log_event_sns(ctevent, body.fetch('id'), true)
-      elsif retrycount <= 20
+      elsif retrycount <= 42
         # put message back on queue
         log.info('No matching CloudWatch event found. Requeuing this event.')
         delay = calculate_delay(retrycount)


### PR DESCRIPTION
Increase retries on CloudTrail events.  Each retry beyond the first 6 adds 15 minutes.  This will accommodate the late arriving events from CloudWatch.

https://github.com/18F/identity-devops/issues/2370