### PR TITLE
Update to check if the event originated in SNS

### DIFF
--- a/lib/kms_monitor/cloudtrail.rb
+++ b/lib/kms_monitor/cloudtrail.rb
@@ -76,9 +76,14 @@ module IdentityKMSMonitor
 
     # @param [Hash] record
     def process_record(record)
+      log.info("event: #{record.inspect}")
       body = JSON.parse(record.fetch('body'))
       log.info("record body: #{body.inspect}")
 
+      originate_sns = body.fetch('Type', :nil)
+      if originate_sns == "Notification"
+        body = JSON.parse(body.fetch('Message'))
+      end
       ctevent = CloudTrailEvent.new
       timestamp = Time.parse(body.fetch('detail').fetch('eventTime')).utc
       time_format = '%Y-%m-%dT%H:%M:%SZ'


### PR DESCRIPTION
KMS log events from CloudTrail will start passing through SNS to accommodate cross region delivery.  Check if in SNS envelope.

### Needs to be deployed prior to KMS changes ###