### PR TITLE
Change default ref from master to main

### DIFF
--- a/lib/audit/repo_content.rb
+++ b/lib/audit/repo_content.rb
@@ -20,7 +20,7 @@ module IdentityAudit
     #   "team/team.yml"
     # @param [Octokit::Client] octokit_client
     # @param [String] ref The name of the Commit/Branch/Tag. Defaults to
-    #   "master"
+    #   "main"
     #
     def self.read_team_yml(team_yml_repo:, team_yml_path:, octokit_client: nil,
                            ref: nil)


### PR DESCRIPTION
This fixes a 404 when executing the lambda

```
"errorMessage": "GET https://api.github.com/repos/18F/identity-private/contents/team/team.yml?ref=master: 404 - Not Found // See: https://docs.github.com/rest/reference/repos#get-repository-content",
```